### PR TITLE
Add SynchronizationContext and GoBack to navigation

### DIFF
--- a/Sylac.Mvvm.Core/Navigation/Abstractions/IPlatformNavigation.cs
+++ b/Sylac.Mvvm.Core/Navigation/Abstractions/IPlatformNavigation.cs
@@ -4,8 +4,11 @@ namespace Sylac.Mvvm.Navigation.Abstractions
 {
     public interface IPlatformNavigation
     {
+        SynchronizationContext SynchronizationContext { get; }
+
         void RegisterPage<TPage>() where TPage : INavigationablePage;
         IObservable<Unit> GoTo(string route);
         IObservable<Unit> GoTo(string route, IDictionary<string, object> parameters);
+        IObservable<Unit> GoBack();
     }
 }

--- a/Sylac.Mvvm.Core/Navigation/NavigationService.cs
+++ b/Sylac.Mvvm.Core/Navigation/NavigationService.cs
@@ -42,6 +42,7 @@ public sealed class NavigationService(IPlatformNavigation platformNavigation) : 
         where TParams : IViewModelParameters
     {
         return Observable.Return(ViewModelsRegistry.GetValueOrDefault(typeof(TViewModel)))
+            .SubscribeOn(_platformNavigation.SynchronizationContext)
             .Where(result => result != default)
             .SelectMany(result =>
                 // is type check needed? Is it possible to pass a different type?
@@ -54,6 +55,8 @@ public sealed class NavigationService(IPlatformNavigation platformNavigation) : 
                 : Observable.Return(Unit.Default));
     }
 
-    public IObservable<Unit> NavigateBack() => _platformNavigation.GoTo("..");
+    public IObservable<Unit> NavigateBack() => Observable.Return(Unit.Default)
+        .SubscribeOn(_platformNavigation.SynchronizationContext)
+        .SelectMany(_ => _platformNavigation.GoBack());
 }
 

--- a/Sylac.Mvvm.Core/Sylac.Mvvm.Core.csproj
+++ b/Sylac.Mvvm.Core/Sylac.Mvvm.Core.csproj
@@ -9,7 +9,7 @@
 		<IsPackable>true</IsPackable>
 		<PackageId>Sylac.Mvvm.Core</PackageId>
     <RootNamespace>Sylac.Mvvm</RootNamespace>
-		<Version>0.3.0</Version>
+		<Version>0.3.1</Version>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Authors>Sylwester Łach</Authors>
     <RepositoryUrl>https://github.com/sylac/Sylac.Mvvm</RepositoryUrl>

--- a/Sylac.Mvvm.Maui/Navigation/MauiNavigation.cs
+++ b/Sylac.Mvvm.Maui/Navigation/MauiNavigation.cs
@@ -6,6 +6,21 @@ namespace Sylac.Mvvm.Maui.Navigation
 {
     public class MauiNavigation : IPlatformNavigation
     {
+        public SynchronizationContext SynchronizationContext
+        {
+            get
+            {
+                try
+                {
+                    return MainThread.GetMainThreadSynchronizationContextAsync().GetAwaiter().GetResult();
+                }
+                catch (Exception ex)
+                {
+                    throw new InvalidOperationException("Failed to get the main thread synchronization context.", ex);
+                }
+            }
+        }
+
         public void RegisterPage<TPage>() where TPage : INavigationablePage
             => Routing.RegisterRoute(typeof(TPage).Name, typeof(TPage));
 
@@ -15,6 +30,10 @@ namespace Sylac.Mvvm.Maui.Navigation
 
         public IObservable<Unit> GoTo(string route, IDictionary<string, object> parameters) => Shell.Current
             .GoToAsync(route, parameters)
+            .ToObservable();
+
+        public IObservable<Unit> GoBack() => Shell.Current
+            .GoToAsync("..")
             .ToObservable();
     }
 }

--- a/Sylac.Mvvm.Maui/Sylac.Mvvm.Maui.csproj
+++ b/Sylac.Mvvm.Maui/Sylac.Mvvm.Maui.csproj
@@ -12,7 +12,7 @@
     <!-- NUGET PACKAGE SETTINGS -->
 		<IsPackable>true</IsPackable>
 		<PackageId>Sylac.Mvvm.Maui</PackageId>
-		<Version>0.3.0</Version>
+		<Version>0.3.1</Version>
 		<Authors>Sylwester Łach</Authors>
 		<RepositoryUrl>https://github.com/sylac/Sylac.Mvvm</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>

--- a/Tests/Sylac.Mvvm.UnitTests/NavigationServiceTests.cs
+++ b/Tests/Sylac.Mvvm.UnitTests/NavigationServiceTests.cs
@@ -54,6 +54,8 @@ namespace Sylac.Mvvm.UnitTests
             var navigationService = new NavigationService(shellWrapper);
             navigationService.RegisterNavigationView<TestPage, TestViewModel, TestViewModelParameters>();
 
+            _ = shellWrapper.SynchronizationContext.Returns(SynchronizationContext.Current);
+
             // Act
             var result = await navigationService
                 .NavigateTo<TestViewModel, TestViewModelParameters>(new("TestString"))
@@ -61,8 +63,8 @@ namespace Sylac.Mvvm.UnitTests
 
             // Assert
             Assert.Equal(Unit.Default, result);
-            await shellWrapper
-                .Received()
+            _ = await shellWrapper
+                .Received(1)
                 .GoTo(nameof(TestPage), Arg.Any<Dictionary<string, object>>())
                 .ToTask();
 
@@ -76,8 +78,10 @@ namespace Sylac.Mvvm.UnitTests
             var shellWrapper = Substitute.For<IPlatformNavigation>();
             var navigationService = new NavigationService(shellWrapper);
 
+            _ = shellWrapper.SynchronizationContext.Returns(SynchronizationContext.Current);
+
             // Act & Assert
-            await Assert.ThrowsAsync<ArgumentException>(() => navigationService
+            _ = await Assert.ThrowsAsync<ArgumentException>(() => navigationService
                     .NavigateTo<TestViewModel2, TestViewModelParameters2>(new("TestString"))
                     .ToTask());
 
@@ -96,8 +100,10 @@ namespace Sylac.Mvvm.UnitTests
                 Assert.Fail("Failed to add TestViewModel to ViewModelsRegistry");
             }
 
+            _ = shellWrapper.SynchronizationContext.Returns(SynchronizationContext.Current);
+
             // Act & Assert
-            await Assert.ThrowsAsync<ArgumentException>(() => navigationService
+            _ = await Assert.ThrowsAsync<ArgumentException>(() => navigationService
                     .NavigateTo<TestViewModel, TestViewModelParameters>(new("TestString"))
                     .ToTask());
 
@@ -111,11 +117,12 @@ namespace Sylac.Mvvm.UnitTests
             var navigationService = new NavigationService(shellWrapper);
             navigationService.RegisterNavigationView<TestPage, TestViewModel, TestViewModelParameters>();
 
-            shellWrapper.GoTo(nameof(TestPage), Arg.Any<Dictionary<string, object>>())
+            _ = shellWrapper.SynchronizationContext.Returns(SynchronizationContext.Current);
+            _ = shellWrapper.GoTo(nameof(TestPage), Arg.Any<Dictionary<string, object>>())
                 .Returns(Observable.Throw<Unit>(new Exception("Error navigating to page")));
 
             // Act & Assert
-            await Assert.ThrowsAsync<Exception>(() => navigationService
+            _ = await Assert.ThrowsAsync<Exception>(() => navigationService
                     .NavigateTo<TestViewModel, TestViewModelParameters>(new("TestString"))
                     .ToTask());
 
@@ -129,12 +136,14 @@ namespace Sylac.Mvvm.UnitTests
             var shellWrapper = Substitute.For<IPlatformNavigation>();
             var navigationService = new NavigationService(shellWrapper);
 
+            _ = shellWrapper.SynchronizationContext.Returns(SynchronizationContext.Current);
+
             // Act
             var result = await navigationService.NavigateBack().ToTask();
 
             // Assert
             Assert.Equal(Unit.Default, result);
-            await shellWrapper.Received().GoTo("..").ToTask();
+            _ = await shellWrapper.Received(1).GoBack().ToTask();
         }
 
         private record TestViewModelParameters(string TestString) : IViewModelParameters;


### PR DESCRIPTION
Added SynchronizationContext property and GoBack method to IPlatformNavigation interface. Updated NavigationService to use SynchronizationContext for subscribing and GoBack for navigation. Implemented these changes in MauiNavigation class. Incremented version numbers in Sylac.Mvvm.Core.csproj and Sylac.Mvvm.Maui.csproj to 0.3.1.